### PR TITLE
Updates .gitattributes and adds an .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.ps1]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto eol=lf
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
-*.{ps1,[pP][sS]1} text eol=crlf
+* text eol=lf
+*.cmd text eol=crlf
+*.bat text eol=crlf
+*.ps1 text eol=crlf


### PR DESCRIPTION
Git stores data (including text) as blobs; if your text has LF line endings, CRLF line endings, or some mix, git doesn't really care and will happily store whatever line endings it gets.  It's only when useful things like reading or writing those blobs, on useful platforms like Windows, OSX, or Linux, does everything get messy.

Native line endings on Windows are CRLF, and native line endings for Linux are LF, so it might make some intuitive sense that you could just tell git to change the line endings based on the platform.  In fact, this is essentially what setting `core.autocrlf = true` in your personal `~/.gitconfig` does.

The problem is that certain files need to have LF line endings (e.g. Bash will want your `sh` files to have LF line endings), and certain files need to have CRLF line endings (Visual Studio will want your `sln` files to have CRLF line endings).  This becomes a problem if line endings change based on the platform.  It becomes a bigger problem if developers can choose (accidentally or intentionally) to commit whatever line endings they want.

That's why it's better to have a `.gitattributes` file that controls this centrally.

# .gitattributes

- Setting the `text` attribute tells git to "normalize" all line endings (aka convert them to LF).
- Setting the `eol` attribute tells git which line endings to normalize to.
- Not setting the `text=auto` tells git this is a text file; its going to be normalized.  Prefer to explicitly tell git if the file is text or not.

##  Writing to git

When git writes data from your working tree to the index, it can optionally convert line endings from CRLF -> LF.  This is the only direction git will convert line endings on a write.

- If `eol=lf` or `eol=crlf` are set, CRLF line endings are converted to LF.  Note that if you have CR line endings for some reason, they won't be converted to LF.
- If `eol` is unset, all line endings added to the index as is _(probably not what you want)_.

That is, "normalized" text files are stored with LF only, even if they are meant to be written to your working tree with CRLF.

## Read from git

When git writes data to your working tree, it can optionally convert line endings from LF -> CRLF.  This is the only direction git will convert line endings on a read.

- If `eol=lf` is set, or if `eol` is unset, then all line endings are read as is.
- If `eol=crlf` is set, then all LF line endings are converted to CRLF.  Note that if you have CR line endings, they won't be converted to CRLF.

# .editorconfig

Whereas the `.gitattributes` file is present to ensure a consistent developer experience with git, the `.editorconfig` is present to ensure a consitent developer experience with tooling and editors.  Given that all the logic around `core.autocrlf`/`core.eol` exist to make git behave nicely with other editors and tooling, it probably makes more sense to leave them their default values and let editorconfig take care of that problem.

These are the defaults:

```
[core]
  autocrlf = false
  eol = native
```

I realize there are articles around the internet that say `core.autocrlf = true` is the way to go, but good luck making sure every developer working on your project has set the appropriate values on their local machine.  It's much easier to check if the `.gitattributes` file is correct.

# References

- See https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration
- See https://git-scm.com/docs/gitattributes
- See https://stackoverflow.com/questions/2825428/why-should-i-use-core-autocrlf-true-in-git